### PR TITLE
Fixed tests to match current return values from the lib/codes directory

### DIFF
--- a/lib/NMEA.js
+++ b/lib/NMEA.js
@@ -10,6 +10,7 @@ var MWV = require("./codes/MWV.js");
 var DBT = require("./codes/DBT.js");
 var HDG = require("./codes/HDG.js");
 var VHW = require("./codes/VHW.js");
+var VWR = require("./codes/VWR.js");
 var Helper = require("./Helper.js");
 
 /** NMEA module */
@@ -185,6 +186,7 @@ var NMEA = ( function() {
     nmea.addParser(new GLL.Decoder("GPGLL"));
     nmea.addParser(new HDG.Decoder("HCHDG"));
     nmea.addParser(new VHW.Decoder("VWVHW"));
+    nmea.addParser(new VWR.Decoder("IIVWR"));
     // add the standard encoders
     nmea.addEncoder(new GGA.Encoder("GPGGA"));
     nmea.addEncoder(new RMC.Encoder("GPRMC"));

--- a/lib/NMEA.js
+++ b/lib/NMEA.js
@@ -185,7 +185,7 @@ var NMEA = ( function() {
     nmea.addParser(new DBT.Decoder("SDDBT"));
     nmea.addParser(new GLL.Decoder("GPGLL"));
     nmea.addParser(new HDG.Decoder("HCHDG"));
-    nmea.addParser(new VHW.Decoder("VWVHW"));
+    nmea.addParser(new VHW.Decoder("IIVHW"));
     nmea.addParser(new VWR.Decoder("IIVWR"));
     // add the standard encoders
     nmea.addEncoder(new GGA.Encoder("GPGGA"));

--- a/lib/codes/VWR.js
+++ b/lib/codes/VWR.js
@@ -1,0 +1,51 @@
+
+var Helper = require("../Helper.js");
+
+/*
+
+VWR - Relative Wind Speed and Angle
+         1  2  3  4  5  6  7  8 9
+         |  |  |  |  |  |  |  | |
+ $--VWR,x.x,a,x.x,N,x.x,M,x.x,K*hh<CR><LF>
+Field Number:
+
+1. Wind direction magnitude in degrees
+2. Wind direction Left/Right of bow
+3. Speed
+4. N = Knots
+5. Speed
+6. M = Meters Per Second
+7. Speed
+8. K = Kilometers Per Hour
+9. Checksum
+ */
+
+exports.Decoder = function (id) {
+    this.id = id;
+    this.talker_type_id = "VWR";
+    this.talker_type_desc = "Relative Wind Speed and Angle";
+    this._reference = function(char){
+        switch(char){
+            case "N" : return "Knots"
+            case "M" : return "Meters Per Second"
+            case "K" : return "Kilometers Per Hour"
+        }  
+    };
+
+    this.parse = function (tokens) {
+        if (tokens.length < 9) {
+            throw new Error('VWR : not enough tokens');
+        }
+
+        return {
+            id: tokens[0].substr(1),
+            talker_type_id: this.talker_type_id,
+            talker_type_desc: this.talker_type_desc,
+            wind_direction_degrees: Helper.parseFloatX(tokens[1]),
+            wind_direction_bow: Helper.parseFloatX(tokens[2]),
+            sow_knots: Helper.parseFloatX(tokens[3]),
+            sow_mps: Helper.parseFloatX(tokens[4]),
+            sow_kph: Helper.parseFloatX(tokens[5])
+        }
+    };
+};

--- a/lib/codes/VWR.js
+++ b/lib/codes/VWR.js
@@ -41,11 +41,11 @@ exports.Decoder = function (id) {
             id: tokens[0].substr(1),
             talker_type_id: this.talker_type_id,
             talker_type_desc: this.talker_type_desc,
-            wind_direction_degrees: Helper.parseFloatX(tokens[1]),
-            wind_direction_bow: Helper.parseFloatX(tokens[2]),
-            sow_knots: Helper.parseFloatX(tokens[3]),
-            sow_mps: Helper.parseFloatX(tokens[4]),
-            sow_kph: Helper.parseFloatX(tokens[5])
+            apparent_wind_angle: Helper.parseFloatX(tokens[1]),
+            apparent_wind_off_bow: Helper.parseFloatX(tokens[2]),
+            apparent_wind_speed_knots: Helper.parseFloatX(tokens[3]),
+            apparent_wind_speed_mps: Helper.parseFloatX(tokens[4]),
+            apparent_wind_speed_kph: Helper.parseFloatX(tokens[5])
         }
     };
 };

--- a/test/nmea.test.js
+++ b/test/nmea.test.js
@@ -151,6 +151,16 @@ describe('nmea',function() {
         }
     });
 
+    it("VWR parse", function() {
+       var s = "IIVWR";
+       var n = nmea.parse("$IIVWR,23.4,R,9.09,N,4.67,M,16.8,K*46");
+       assert.ok(n !== null,'parser result not null');
+       if (n !== null) {
+         assert.ok(n.id === s,s + '!== ' + n.id);
+       }
+
+    })
+
 
     it("encode latitude", function () {
         var s;

--- a/test/nmea.test.js
+++ b/test/nmea.test.js
@@ -158,8 +158,17 @@ describe('nmea',function() {
        if (n !== null) {
          assert.ok(n.id === s,s + '!== ' + n.id);
        }
-
     })
+
+    it("VHW parse", function() {
+       var s = "IIVHW";
+       var n = nmea.parse("$IIVHW,183.0,T,171.0,M,3.63,N.4.56,K*5B");
+       assert.ok(n !== null,'parser result not null');
+       if (n !== null) {
+         assert.ok(n.id === s,s + '!== ' + n.id);
+       }
+    })
+
 
 
     it("encode latitude", function () {

--- a/test/nmea.test.js
+++ b/test/nmea.test.js
@@ -54,7 +54,7 @@ describe('nmea',function() {
             assert.equal(n.valid,'A','valid');
             assert.strictEqual(n.latitude,(-(37.0 + (51.65/60.0))).toFixed(8),'latitude');
             assert.strictEqual(n.longitude,(145.0 + (7.36 / 60.0)).toFixed(8),'longitude');
-            assert.strictEqual(n.speed,0.0,'speed');
+            assert.strictEqual(n.sog,0.0,'sog');
             assert.strictEqual(n.course,360.0,'course');
             assert.equal(n.date,'130998','date');
             assert.strictEqual(n.variation,-11.3,'variation');
@@ -132,10 +132,10 @@ describe('nmea',function() {
         assert.ok(n !== null, 'parser result not null');
         if (n !== null) {
             assert.ok(n.id === s, s + '!== ' + n.id);
-            assert.equal(n.angle, 17);
-            assert.equal(n.reference, 'R');
-            assert.equal(n.speed, 2.91);
-            assert.equal(n.status, 'A');
+            assert.equal(n.apparent_wind_angle, 17);
+            assert.equal(n.reference, 'relative');
+            assert.equal(n.apparent_wind_speed, 2.91);
+            assert.equal(n.status, 'data valid');
         }
     });
 
@@ -146,8 +146,8 @@ describe('nmea',function() {
         assert.ok(n !== null, 'parser result not null');
         if (n !== null) {
             assert.ok(n.id === s, s + '!== ' + n.id);
-            assert.equal(n.depthFeet, 36.41);
-            assert.equal(n.depthMeters, 11.1);
+            assert.equal(n.feet, 36.41);
+            assert.equal(n.meters, 11.1);
         }
     });
 


### PR DESCRIPTION
I've fixed the tests so that they now pass based upon the data formats in the lib/codes directory.
