### PR TITLE
Supporting GNGGA sentences

### DIFF
--- a/lib/NMEA.js
+++ b/lib/NMEA.js
@@ -174,6 +174,7 @@ var NMEA = ( function() {
 
     // add the standard decoders
     nmea.addParser(new GGA.Decoder("GPGGA"));
+    nmea.addParser(new GGA.Decoder("GNGGA"));
     nmea.addParser(new RMC.Decoder("GPRMC"));
     nmea.addParser(new GSV.Decoder("GPGSV"));
     nmea.addParser(new GSA.Decoder("GPGSA"));


### PR DESCRIPTION
Using the GPGGA parser, you can easily parse the GNGGA sentences, corresponding to NMEA-0183 v4.x as the GPGGA is already ignoring the first two characters

Modern GNSS receivers are using concurrent systems (GPS, GLONASS, BeiDou, Galileo) at the same time together. For such "combined" positioning, the correct messages ID prefix is “$GN”

Some test data if you need:

``` javascript
NMEA.parse("$GNGGA,054157.013,2307.1261,N,12016.4308,E,1,6,1.93,34.9,M,17.8,M,,*76")
```
